### PR TITLE
Fix bug that DateTimePicker sets a wrong date when change the hour in 24 hour mode

### DIFF
--- a/src/net/micode/notes/ui/DateTimePicker.java
+++ b/src/net/micode/notes/ui/DateTimePicker.java
@@ -78,6 +78,7 @@ public class DateTimePicker extends FrameLayout {
         public void onValueChange(NumberPicker picker, int oldVal, int newVal) {
             boolean isDateChanged = false;
             Calendar cal = Calendar.getInstance();
+            int newHour;
             if (!mIs24HourView) {
                 if (!mIsAm && oldVal == HOURS_IN_HALF_DAY - 1 && newVal == HOURS_IN_HALF_DAY) {
                     cal.setTimeInMillis(mDate.getTimeInMillis());
@@ -93,6 +94,7 @@ public class DateTimePicker extends FrameLayout {
                     mIsAm = !mIsAm;
                     updateAmPmControl();
                 }
+                newHour = mHourSpinner.getValue() % HOURS_IN_HALF_DAY + (mIsAm ? 0 : HOURS_IN_HALF_DAY);
             } else {
                 if (oldVal == HOURS_IN_ALL_DAY - 1 && newVal == 0) {
                     cal.setTimeInMillis(mDate.getTimeInMillis());
@@ -103,8 +105,8 @@ public class DateTimePicker extends FrameLayout {
                     cal.add(Calendar.DAY_OF_YEAR, -1);
                     isDateChanged = true;
                 }
+                newHour = mHourSpinner.getValue();
             }
-            int newHour = mHourSpinner.getValue() % HOURS_IN_HALF_DAY + (mIsAm ? 0 : HOURS_IN_HALF_DAY);
             mDate.set(Calendar.HOUR_OF_DAY, newHour);
             onDateTimeChanged();
             if (isDateChanged) {


### PR DESCRIPTION
Fix bug that DateTimePicker sets a wrong date when change the hour in 24 hour mode

MIUI-1216

Fix bug that DateTimePicker sets a wrong date when change the hour in 24 hour mode

Signed-off-by: zhaohad zhaohad@zhaohad-OptiPlex-990.localdomain
