### PR TITLE
Fix SDCard folder cannot created when backup notes.

### DIFF
--- a/src/net/micode/notes/tool/BackupUtils.java
+++ b/src/net/micode/notes/tool/BackupUtils.java
@@ -325,7 +325,7 @@ public class BackupUtils {
 
         try {
             if (!filedir.exists()) {
-                filedir.mkdir();
+                filedir.mkdirs();  // filedir creates failed [fix]
             }
             if (!file.exists()) {
                 file.createNewFile();


### PR DESCRIPTION
Bugs occured at HUAWEI honor(ICS 4.0.4).
