### PR TITLE
styles.xml -- 将android:visibility的值改为visible

### DIFF
--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -64,6 +64,6 @@
 
     <style name="NoteActionBarStyle" parent="@android:style/Widget.Holo.Light.ActionBar.Solid">
         <item name="android:displayOptions" />
-        <item name="android:visibility">gone</item>
+        <item name="android:visibility">visible</item>
     </style>
 </resources>


### PR DESCRIPTION
有些学校的软件工程课要让开发这个工程；这里设为gone会使一些模拟环境下显示不出菜单栏，对于缺乏经验的学生来说，会造成不小的麻烦；这个修改应该能帮到许多人。